### PR TITLE
Monster Soul Converter fix (?) and missing item for BoK

### DIFF
--- a/ItemBags/Item_(14,11,11)_Kundun_Box+4.xml
+++ b/ItemBags/Item_(14,11,11)_Kundun_Box+4.xml
@@ -75,6 +75,8 @@
 			<Item Cat="10" Index="95" ItemMinLevel="0" ItemMaxLevel="0" Skill="1" Luck="1" Option="-1" Exc="-2" SetItem="0" SocketCount="0" SocketInfo="-1" ElementalItem="0" />
 			<!--Sate Boots-->
 			<Item Cat="11" Index="95" ItemMinLevel="0" ItemMaxLevel="0" Skill="1" Luck="1" Option="-1" Exc="-2" SetItem="0" SocketCount="0" SocketInfo="-1" ElementalItem="0" />
+			<!--Kenaz Hood-->
+			<Item Cat="7" Index="119" ItemMinLevel="0" ItemMaxLevel="0" Skill="1" Luck="1" Option="-1" Exc="-2" SetItem="0" SocketCount="0" SocketInfo="-1" ElementalItem="0" />
 			<!--Kanaz Armor-->
 			<Item Cat="8" Index="119" ItemMinLevel="0" ItemMaxLevel="0" Skill="1" Luck="1" Option="-1" Exc="-2" SetItem="0" SocketCount="0" SocketInfo="-1" ElementalItem="0" />
 			<!--Kanaz Pants-->

--- a/ItemBags/Item_(14,11,12)_Kundun_Box+5.xml
+++ b/ItemBags/Item_(14,11,12)_Kundun_Box+5.xml
@@ -219,6 +219,8 @@
 			<Item Cat="10" Index="95" ItemMinLevel="0" ItemMaxLevel="0" Skill="1" Luck="1" Option="-1" Exc="-2" SetItem="0" SocketCount="0" SocketInfo="-1" ElementalItem="0" />
 			<!--Sate Boots-->
 			<Item Cat="11" Index="95" ItemMinLevel="0" ItemMaxLevel="0" Skill="1" Luck="1" Option="-1" Exc="-2" SetItem="0" SocketCount="0" SocketInfo="-1" ElementalItem="0" />
+			<!--Kenaz Hood-->
+			<Item Cat="7" Index="119" ItemMinLevel="0" ItemMaxLevel="0" Skill="1" Luck="1" Option="-1" Exc="-2" SetItem="0" SocketCount="0" SocketInfo="-1" ElementalItem="0" />			
 			<!--Kanaz Armor-->
 			<Item Cat="8" Index="119" ItemMinLevel="0" ItemMaxLevel="0" Skill="1" Luck="1" Option="-1" Exc="-2" SetItem="0" SocketCount="0" SocketInfo="-1" ElementalItem="0" />
 			<!--Kanaz Pants-->

--- a/Items/Drop/MonsterSoulConversion.xml
+++ b/Items/Drop/MonsterSoulConversion.xml
@@ -51,97 +51,97 @@
 <WeeklyReset Day="4" Hour="10" Minute="30" Second="0" />
 
 	<ConverterSettings>
-		<Converter Level="1" Cat="14" Index="460" ReqSoulNumber="2"/>
-		<Converter Level="2" Cat="14" Index="461" ReqSoulNumber="2"/>
-		<Converter Level="3" Cat="14" Index="462" ReqSoulNumber="2"/>
-		<Converter Level="4" Cat="14" Index="463" ReqSoulNumber="2"/>
-		<Converter Level="5" Cat="14" Index="464" ReqSoulNumber="2"/>
+		<Converter Level="1" Cat="14" Index="460" ReqSoulNumber="1"/>
+		<Converter Level="2" Cat="14" Index="461" ReqSoulNumber="1"/>
+		<Converter Level="3" Cat="14" Index="462" ReqSoulNumber="1"/>
+		<Converter Level="4" Cat="14" Index="463" ReqSoulNumber="1"/>
+		<Converter Level="5" Cat="14" Index="464" ReqSoulNumber="1"/>
 	</ConverterSettings>
 
 	<MonsterSettings>
 		<Converter Level="1">
-			<Area ID="0"  MapNumber="91" MonsterIndex="586" ReqSoulNumber="500" DropRate="450000" Name="Acheron" />
-			<Area ID="1"  MapNumber="91" MonsterIndex="587" ReqSoulNumber="500" DropRate="450000" Name="Acheron" />
-			<Area ID="2"  MapNumber="91" MonsterIndex="588" ReqSoulNumber="500" DropRate="450000" Name="Acheron" />
-			<Area ID="3"  MapNumber="91" MonsterIndex="589" ReqSoulNumber="500" DropRate="450000" Name="Acheron" />
-			<Area ID="4"  MapNumber="91" MonsterIndex="590" ReqSoulNumber="500" DropRate="450000" Name="Acheron" />
-			<Area ID="5"  MapNumber="91" MonsterIndex="591" ReqSoulNumber="500" DropRate="450000" Name="Acheron" />
-			<Area ID="6"  MapNumber="63" MonsterIndex="480" ReqSoulNumber="500" DropRate="450000" Name="Vulcanus" />
-			<Area ID="7"  MapNumber="63" MonsterIndex="482" ReqSoulNumber="500" DropRate="450000" Name="Vulcanus" />
-			<Area ID="8"  MapNumber="63" MonsterIndex="484" ReqSoulNumber="500" DropRate="450000" Name="Vulcanus" />
-			<Area ID="9"  MapNumber="63" MonsterIndex="486" ReqSoulNumber="500" DropRate="450000" Name="Vulcanus" />
-			<Area ID="10" MapNumber="63" MonsterIndex="487" ReqSoulNumber="500" DropRate="450000" Name="Vulcanus" />
-			<Area ID="11" MapNumber="63" MonsterIndex="489" ReqSoulNumber="500" DropRate="450000" Name="Vulcanus" />
-			<Area ID="12" MapNumber="63" MonsterIndex="490" ReqSoulNumber="500" DropRate="450000" Name="Vulcanus" />
-			<Area ID="13" MapNumber="29" MonsterIndex="271" ReqSoulNumber="500" DropRate="450000" Name="Kalima 6" />
-			<Area ID="14" MapNumber="29" MonsterIndex="272" ReqSoulNumber="500" DropRate="450000" Name="Kalima 6" />
-			<Area ID="15" MapNumber="29" MonsterIndex="270" ReqSoulNumber="500" DropRate="450000" Name="Kalima 6" />
-			<Area ID="16" MapNumber="29" MonsterIndex="268" ReqSoulNumber="500" DropRate="450000" Name="Kalima 6" />
-			<Area ID="17" MapNumber="29" MonsterIndex="273" ReqSoulNumber="500" DropRate="450000" Name="Kalima 6" />
-			<Area ID="18" MapNumber="29" MonsterIndex="269" ReqSoulNumber="500" DropRate="450000" Name="Kalima 6" />
-			<Area ID="19" MapNumber="29" MonsterIndex="274" ReqSoulNumber="500" DropRate="450000" Name="Kalima 6" />
-			<Area ID="20" MapNumber="36" MonsterIndex="331" ReqSoulNumber="500" DropRate="450000" Name="Kalima 7" />
-			<Area ID="21" MapNumber="36" MonsterIndex="332" ReqSoulNumber="500" DropRate="450000" Name="Kalima 7" />
-			<Area ID="22" MapNumber="36" MonsterIndex="333" ReqSoulNumber="500" DropRate="450000" Name="Kalima 7" />
-			<Area ID="23" MapNumber="36" MonsterIndex="334" ReqSoulNumber="500" DropRate="450000" Name="Kalima 7" />
-			<Area ID="24" MapNumber="36" MonsterIndex="335" ReqSoulNumber="500" DropRate="450000" Name="Kalima 7" />
-			<Area ID="25" MapNumber="36" MonsterIndex="336" ReqSoulNumber="500" DropRate="450000" Name="Kalima 7" />
-			<Area ID="26" MapNumber="36" MonsterIndex="337" ReqSoulNumber="500" DropRate="450000" Name="Kalima 7" />
-			<Area ID="27" MapNumber="33" MonsterIndex="308" ReqSoulNumber="500" DropRate="450000" Name="Aida" />
-			<Area ID="28" MapNumber="33" MonsterIndex="307" ReqSoulNumber="500" DropRate="450000" Name="Aida" />
-			<Area ID="29" MapNumber="33" MonsterIndex="306" ReqSoulNumber="500" DropRate="450000" Name="Aida" />
-			<Area ID="30" MapNumber="33" MonsterIndex="305" ReqSoulNumber="500" DropRate="450000" Name="Aida" />
+			<Area ID="0"  MapNumber="91" MonsterIndex="586" ReqSoulNumber="1000" DropRate="450000" Name="Acheron" />
+			<Area ID="1"  MapNumber="91" MonsterIndex="587" ReqSoulNumber="1000" DropRate="450000" Name="Acheron" />
+			<Area ID="2"  MapNumber="91" MonsterIndex="588" ReqSoulNumber="1000" DropRate="450000" Name="Acheron" />
+			<Area ID="3"  MapNumber="91" MonsterIndex="589" ReqSoulNumber="1000" DropRate="450000" Name="Acheron" />
+			<Area ID="4"  MapNumber="91" MonsterIndex="590" ReqSoulNumber="1000" DropRate="450000" Name="Acheron" />
+			<Area ID="5"  MapNumber="91" MonsterIndex="591" ReqSoulNumber="1000" DropRate="450000" Name="Acheron" />
+			<Area ID="6"  MapNumber="63" MonsterIndex="480" ReqSoulNumber="1000" DropRate="450000" Name="Vulcanus" />
+			<Area ID="7"  MapNumber="63" MonsterIndex="482" ReqSoulNumber="1000" DropRate="450000" Name="Vulcanus" />
+			<Area ID="8"  MapNumber="63" MonsterIndex="484" ReqSoulNumber="1000" DropRate="450000" Name="Vulcanus" />
+			<Area ID="9"  MapNumber="63" MonsterIndex="486" ReqSoulNumber="1000" DropRate="450000" Name="Vulcanus" />
+			<Area ID="10" MapNumber="63" MonsterIndex="487" ReqSoulNumber="1000" DropRate="450000" Name="Vulcanus" />
+			<Area ID="11" MapNumber="63" MonsterIndex="489" ReqSoulNumber="1000" DropRate="450000" Name="Vulcanus" />
+			<Area ID="12" MapNumber="63" MonsterIndex="490" ReqSoulNumber="1000" DropRate="450000" Name="Vulcanus" />
+			<Area ID="13" MapNumber="29" MonsterIndex="271" ReqSoulNumber="1000" DropRate="450000" Name="Kalima 6" />
+			<Area ID="14" MapNumber="29" MonsterIndex="272" ReqSoulNumber="1000" DropRate="450000" Name="Kalima 6" />
+			<Area ID="15" MapNumber="29" MonsterIndex="270" ReqSoulNumber="1000" DropRate="450000" Name="Kalima 6" />
+			<Area ID="16" MapNumber="29" MonsterIndex="268" ReqSoulNumber="1000" DropRate="450000" Name="Kalima 6" />
+			<Area ID="17" MapNumber="29" MonsterIndex="273" ReqSoulNumber="1000" DropRate="450000" Name="Kalima 6" />
+			<Area ID="18" MapNumber="29" MonsterIndex="269" ReqSoulNumber="1000" DropRate="450000" Name="Kalima 6" />
+			<Area ID="19" MapNumber="29" MonsterIndex="274" ReqSoulNumber="1000" DropRate="450000" Name="Kalima 6" />
+			<Area ID="20" MapNumber="36" MonsterIndex="331" ReqSoulNumber="1000" DropRate="450000" Name="Kalima 7" />
+			<Area ID="21" MapNumber="36" MonsterIndex="332" ReqSoulNumber="1000" DropRate="450000" Name="Kalima 7" />
+			<Area ID="22" MapNumber="36" MonsterIndex="333" ReqSoulNumber="1000" DropRate="450000" Name="Kalima 7" />
+			<Area ID="23" MapNumber="36" MonsterIndex="334" ReqSoulNumber="1000" DropRate="450000" Name="Kalima 7" />
+			<Area ID="24" MapNumber="36" MonsterIndex="335" ReqSoulNumber="1000" DropRate="450000" Name="Kalima 7" />
+			<Area ID="25" MapNumber="36" MonsterIndex="336" ReqSoulNumber="1000" DropRate="450000" Name="Kalima 7" />
+			<Area ID="26" MapNumber="36" MonsterIndex="337" ReqSoulNumber="1000" DropRate="450000" Name="Kalima 7" />
+			<Area ID="27" MapNumber="33" MonsterIndex="308" ReqSoulNumber="1000" DropRate="450000" Name="Aida" />
+			<Area ID="28" MapNumber="33" MonsterIndex="307" ReqSoulNumber="1000" DropRate="450000" Name="Aida" />
+			<Area ID="29" MapNumber="33" MonsterIndex="306" ReqSoulNumber="1000" DropRate="450000" Name="Aida" />
+			<Area ID="30" MapNumber="33" MonsterIndex="305" ReqSoulNumber="1000" DropRate="450000" Name="Aida" />
 		</Converter>
 		<Converter Level="2">
-			<Area ID="0" MapNumber="37" MonsterIndex="553" ReqSoulNumber="500" DropRate="450000" Name="Kanturu Ruins" />
-			<Area ID="1" MapNumber="37" MonsterIndex="554" ReqSoulNumber="500" DropRate="450000" Name="Kanturu Ruins" />
-			<Area ID="2" MapNumber="37" MonsterIndex="555" ReqSoulNumber="500" DropRate="450000" Name="Kanturu Ruins" />
-			<Area ID="3" MapNumber="37" MonsterIndex="556" ReqSoulNumber="500" DropRate="450000" Name="Kanturu Ruins" />
-			<Area ID="4" MapNumber="81" MonsterIndex="571" ReqSoulNumber="500" DropRate="450000" Name="Karutan 2" />
-			<Area ID="5" MapNumber="81" MonsterIndex="572" ReqSoulNumber="500" DropRate="450000" Name="Karutan 2" />
-			<Area ID="6" MapNumber="81" MonsterIndex="575" ReqSoulNumber="500" DropRate="450000" Name="Karutan 2" />
-			<Area ID="7" MapNumber="81" MonsterIndex="576" ReqSoulNumber="500" DropRate="450000" Name="Karutan 2" />
-			<Area ID="8" MapNumber="57" MonsterIndex="562" ReqSoulNumber="500" DropRate="450000" Name="Raklion" />
-			<Area ID="9" MapNumber="57" MonsterIndex="563" ReqSoulNumber="500" DropRate="450000" Name="Raklion" />
-			<Area ID="10" MapNumber="57" MonsterIndex="564" ReqSoulNumber="500" DropRate="450000" Name="Raklion" />
-			<Area ID="11" MapNumber="57" MonsterIndex="565" ReqSoulNumber="500" DropRate="450000" Name="Raklion" />
-			<Area ID="12" MapNumber="56" MonsterIndex="557" ReqSoulNumber="500" DropRate="450000" Name="Swamp of Calmness" />
-			<Area ID="13" MapNumber="56" MonsterIndex="558" ReqSoulNumber="500" DropRate="450000" Name="Swamp of Calmness" />
-			<Area ID="14" MapNumber="56" MonsterIndex="559" ReqSoulNumber="500" DropRate="450000" Name="Swamp of Calmness" />
-			<Area ID="15" MapNumber="112" MonsterIndex="730" ReqSoulNumber="500" DropRate="450000" Name="Ferea" />
-			<Area ID="16" MapNumber="112" MonsterIndex="731" ReqSoulNumber="500" DropRate="450000" Name="Ferea" />
-			<Area ID="17" MapNumber="112" MonsterIndex="732" ReqSoulNumber="500" DropRate="450000" Name="Ferea" />
+			<Area ID="0" MapNumber="37" MonsterIndex="553" ReqSoulNumber="1000" DropRate="450000" Name="Kanturu Ruins" />
+			<Area ID="1" MapNumber="37" MonsterIndex="554" ReqSoulNumber="1000" DropRate="450000" Name="Kanturu Ruins" />
+			<Area ID="2" MapNumber="37" MonsterIndex="555" ReqSoulNumber="1000" DropRate="450000" Name="Kanturu Ruins" />
+			<Area ID="3" MapNumber="37" MonsterIndex="556" ReqSoulNumber="1000" DropRate="450000" Name="Kanturu Ruins" />
+			<Area ID="4" MapNumber="81" MonsterIndex="571" ReqSoulNumber="1000" DropRate="450000" Name="Karutan 2" />
+			<Area ID="5" MapNumber="81" MonsterIndex="572" ReqSoulNumber="1000" DropRate="450000" Name="Karutan 2" />
+			<Area ID="6" MapNumber="81" MonsterIndex="575" ReqSoulNumber="1000" DropRate="450000" Name="Karutan 2" />
+			<Area ID="7" MapNumber="81" MonsterIndex="576" ReqSoulNumber="1000" DropRate="450000" Name="Karutan 2" />
+			<Area ID="8" MapNumber="57" MonsterIndex="562" ReqSoulNumber="1000" DropRate="450000" Name="Raklion" />
+			<Area ID="9" MapNumber="57" MonsterIndex="563" ReqSoulNumber="1000" DropRate="450000" Name="Raklion" />
+			<Area ID="10" MapNumber="57" MonsterIndex="564" ReqSoulNumber="1000" DropRate="450000" Name="Raklion" />
+			<Area ID="11" MapNumber="57" MonsterIndex="565" ReqSoulNumber="1000" DropRate="450000" Name="Raklion" />
+			<Area ID="12" MapNumber="56" MonsterIndex="557" ReqSoulNumber="1000" DropRate="450000" Name="Swamp of Calmness" />
+			<Area ID="13" MapNumber="56" MonsterIndex="558" ReqSoulNumber="1000" DropRate="450000" Name="Swamp of Calmness" />
+			<Area ID="14" MapNumber="56" MonsterIndex="559" ReqSoulNumber="1000" DropRate="450000" Name="Swamp of Calmness" />
+			<Area ID="15" MapNumber="112" MonsterIndex="730" ReqSoulNumber="1000" DropRate="450000" Name="Ferea" />
+			<Area ID="16" MapNumber="112" MonsterIndex="731" ReqSoulNumber="1000" DropRate="450000" Name="Ferea" />
+			<Area ID="17" MapNumber="112" MonsterIndex="732" ReqSoulNumber="1000" DropRate="450000" Name="Ferea" />
 		</Converter>
 		<Converter Level="3">
-			<Area ID="0" MapNumber="113" MonsterIndex="743" ReqSoulNumber="500" DropRate="450000" Name="Nixie Lake" />
-			<Area ID="1" MapNumber="113" MonsterIndex="744" ReqSoulNumber="500" DropRate="450000" Name="Nixie Lake" />
-			<Area ID="2" MapNumber="113" MonsterIndex="745" ReqSoulNumber="500" DropRate="450000" Name="Nixie Lake" />
-			<Area ID="3" MapNumber="116" MonsterIndex="767" ReqSoulNumber="500" DropRate="450000" Name="Deep Dungeon 1" />
-			<Area ID="4" MapNumber="116" MonsterIndex="770" ReqSoulNumber="500" DropRate="450000" Name="Deep Dungeon 1" />
-			<Area ID="5" MapNumber="117" MonsterIndex="771" ReqSoulNumber="500" DropRate="450000" Name="Deep Dungeon 2" />
-			<Area ID="6" MapNumber="117" MonsterIndex="772" ReqSoulNumber="500" DropRate="450000" Name="Deep Dungeon 2" />
-			<Area ID="7" MapNumber="118" MonsterIndex="768" ReqSoulNumber="500" DropRate="450000" Name="Deep Dungeon 3" />
-			<Area ID="8" MapNumber="118" MonsterIndex="773" ReqSoulNumber="500" DropRate="450000" Name="Deep Dungeon 3" />
+			<Area ID="0" MapNumber="113" MonsterIndex="743" ReqSoulNumber="1000" DropRate="450000" Name="Nixie Lake" />
+			<Area ID="1" MapNumber="113" MonsterIndex="744" ReqSoulNumber="1000" DropRate="450000" Name="Nixie Lake" />
+			<Area ID="2" MapNumber="113" MonsterIndex="745" ReqSoulNumber="1000" DropRate="450000" Name="Nixie Lake" />
+			<Area ID="3" MapNumber="116" MonsterIndex="767" ReqSoulNumber="1000" DropRate="450000" Name="Deep Dungeon 1" />
+			<Area ID="4" MapNumber="116" MonsterIndex="770" ReqSoulNumber="1000" DropRate="450000" Name="Deep Dungeon 1" />
+			<Area ID="5" MapNumber="117" MonsterIndex="771" ReqSoulNumber="1000" DropRate="450000" Name="Deep Dungeon 2" />
+			<Area ID="6" MapNumber="117" MonsterIndex="772" ReqSoulNumber="1000" DropRate="450000" Name="Deep Dungeon 2" />
+			<Area ID="7" MapNumber="118" MonsterIndex="768" ReqSoulNumber="1000" DropRate="450000" Name="Deep Dungeon 3" />
+			<Area ID="8" MapNumber="118" MonsterIndex="773" ReqSoulNumber="1000" DropRate="450000" Name="Deep Dungeon 3" />
 		</Converter>
 		<Converter Level="4">
-			<Area ID="0" MapNumber="119" MonsterIndex="769" ReqSoulNumber="500" DropRate="450000" Name="Deep Dungeon 4" />
-			<Area ID="1" MapNumber="119" MonsterIndex="774" ReqSoulNumber="500" DropRate="450000" Name="Deep Dungeon 4" />
-			<Area ID="2" MapNumber="120" MonsterIndex="775" ReqSoulNumber="500" DropRate="450000" Name="Deep Dungeon 5" />
-			<Area ID="3" MapNumber="120" MonsterIndex="776" ReqSoulNumber="500" DropRate="450000" Name="Deep Dungeon 5" />
-			<Area ID="4" MapNumber="120" MonsterIndex="777" ReqSoulNumber="500" DropRate="450000" Name="Deep Dungeon 5" />
-			<Area ID="5" MapNumber="122" MonsterIndex="786" ReqSoulNumber="500" DropRate="450000" Name="Swamp of Darkness" />
-			<Area ID="6" MapNumber="122" MonsterIndex="787" ReqSoulNumber="500" DropRate="450000" Name="Swamp of Darkness" />
-			<Area ID="7" MapNumber="122" MonsterIndex="788" ReqSoulNumber="500" DropRate="450000" Name="Swamp of Darkness" />
-			<Area ID="8" MapNumber="122" MonsterIndex="789" ReqSoulNumber="500" DropRate="450000" Name="Swamp of Darkness" />
+			<Area ID="0" MapNumber="119" MonsterIndex="769" ReqSoulNumber="1000" DropRate="450000" Name="Deep Dungeon 4" />
+			<Area ID="1" MapNumber="119" MonsterIndex="774" ReqSoulNumber="1000" DropRate="450000" Name="Deep Dungeon 4" />
+			<Area ID="2" MapNumber="120" MonsterIndex="775" ReqSoulNumber="1000" DropRate="450000" Name="Deep Dungeon 5" />
+			<Area ID="3" MapNumber="120" MonsterIndex="776" ReqSoulNumber="1000" DropRate="450000" Name="Deep Dungeon 5" />
+			<Area ID="4" MapNumber="120" MonsterIndex="777" ReqSoulNumber="1000" DropRate="450000" Name="Deep Dungeon 5" />
+			<Area ID="5" MapNumber="122" MonsterIndex="786" ReqSoulNumber="1000" DropRate="450000" Name="Swamp of Darkness" />
+			<Area ID="6" MapNumber="122" MonsterIndex="787" ReqSoulNumber="1000" DropRate="450000" Name="Swamp of Darkness" />
+			<Area ID="7" MapNumber="122" MonsterIndex="788" ReqSoulNumber="1000" DropRate="450000" Name="Swamp of Darkness" />
+			<Area ID="8" MapNumber="122" MonsterIndex="789" ReqSoulNumber="1000" DropRate="450000" Name="Swamp of Darkness" />
 		</Converter>
 		<Converter Level="5">
-			<Area ID="0" MapNumber="123" MonsterIndex="810" ReqSoulNumber="500" DropRate="450000" Name="Kubera Mine" />
-			<Area ID="1" MapNumber="123" MonsterIndex="811" ReqSoulNumber="500" DropRate="450000" Name="Kubera Mine" />
-			<Area ID="2" MapNumber="123" MonsterIndex="812" ReqSoulNumber="500" DropRate="450000" Name="Kubera Mine" />
-			<Area ID="3" MapNumber="123" MonsterIndex="813" ReqSoulNumber="500" DropRate="450000" Name="Kubera Mine" />
-			<Area ID="4" MapNumber="123" MonsterIndex="814" ReqSoulNumber="500" DropRate="450000" Name="Kubera Mine" />
-			<Area ID="5" MapNumber="123" MonsterIndex="815" ReqSoulNumber="500" DropRate="450000" Name="Kubera Mine" />
-			<Area ID="6" MapNumber="123" MonsterIndex="816" ReqSoulNumber="500" DropRate="450000" Name="Kubera Mine" />
+			<Area ID="0" MapNumber="123" MonsterIndex="810" ReqSoulNumber="1000" DropRate="450000" Name="Kubera Mine" />
+			<Area ID="1" MapNumber="123" MonsterIndex="811" ReqSoulNumber="1000" DropRate="450000" Name="Kubera Mine" />
+			<Area ID="2" MapNumber="123" MonsterIndex="812" ReqSoulNumber="1000" DropRate="450000" Name="Kubera Mine" />
+			<Area ID="3" MapNumber="123" MonsterIndex="813" ReqSoulNumber="1000" DropRate="450000" Name="Kubera Mine" />
+			<Area ID="4" MapNumber="123" MonsterIndex="814" ReqSoulNumber="1000" DropRate="450000" Name="Kubera Mine" />
+			<Area ID="5" MapNumber="123" MonsterIndex="815" ReqSoulNumber="1000" DropRate="450000" Name="Kubera Mine" />
+			<Area ID="6" MapNumber="123" MonsterIndex="816" ReqSoulNumber="1000" DropRate="450000" Name="Kubera Mine" />
 		</Converter>
 	</MonsterSettings>
 </MonsterSoulConversion>

--- a/Items/Drop/MonsterSoulReward.xml
+++ b/Items/Drop/MonsterSoulReward.xml
@@ -8,10 +8,10 @@
 	<Converter Level="1">
 		<Category Number="1">
 			<RewardKind Number="0">
-				<Reward Type="2" CountMin="400" CountMax="400" ItemCat="-1" ItemIndex="-1" ItemMinLevel="0" ItemMaxLevel="0" Skill="0" Luck="0" Option="0" Exc="-1" SetItem="0" SocketCount="0" ElementalItem="0" Rate="1000000" />
+				<Reward Type="2" CountMin="16" CountMax="16" ItemCat="-1" ItemIndex="-1" ItemMinLevel="0" ItemMaxLevel="0" Skill="0" Luck="0" Option="0" Exc="-1" SetItem="0" SocketCount="0" ElementalItem="0" Rate="1000000" />
 			</RewardKind>
 			<RewardKind Number="1">
-				<Reward Type="2" CountMin="200" CountMax="4000" ItemCat="-1" ItemIndex="-1" ItemMinLevel="0" ItemMaxLevel="0" Skill="0" Luck="0" Option="0" Exc="-1" SetItem="0" SocketCount="0" ElementalItem="0" Rate="500000" />
+				<Reward Type="2" CountMin="8" CountMax="160" ItemCat="-1" ItemIndex="-1" ItemMinLevel="0" ItemMaxLevel="0" Skill="0" Luck="0" Option="0" Exc="-1" SetItem="0" SocketCount="0" ElementalItem="0" Rate="500000" />
 				<Reward Type="0" CountMin="1" CountMax="1" ItemCat="14" ItemIndex="371" ItemMinLevel="0" ItemMaxLevel="0" Skill="0" Luck="0" Option="0" Exc="-1" SetItem="0" SocketCount="0" ElementalItem="0" Rate="500000" />
 			</RewardKind>
 		</Category>
@@ -66,10 +66,10 @@
 	<Converter Level="2">
 		<Category Number="1">
 			<RewardKind Number="0">
-				<Reward Type="2" CountMin="400" CountMax="400" ItemCat="-1" ItemIndex="-1" ItemMinLevel="0" ItemMaxLevel="0" Skill="0" Luck="0" Option="0" Exc="-1" SetItem="0" SocketCount="0" ElementalItem="0" Rate="1000000" />
+				<Reward Type="2" CountMin="16" CountMax="16" ItemCat="-1" ItemIndex="-1" ItemMinLevel="0" ItemMaxLevel="0" Skill="0" Luck="0" Option="0" Exc="-1" SetItem="0" SocketCount="0" ElementalItem="0" Rate="1000000" />
 			</RewardKind>
 			<RewardKind Number="1">
-				<Reward Type="2" CountMin="200" CountMax="4000" ItemCat="-1" ItemIndex="-1" ItemMinLevel="0" ItemMaxLevel="0" Skill="0" Luck="0" Option="0" Exc="-1" SetItem="0" SocketCount="0" ElementalItem="0" Rate="500000" />
+				<Reward Type="2" CountMin="8" CountMax="160" ItemCat="-1" ItemIndex="-1" ItemMinLevel="0" ItemMaxLevel="0" Skill="0" Luck="0" Option="0" Exc="-1" SetItem="0" SocketCount="0" ElementalItem="0" Rate="500000" />
 				<Reward Type="0" CountMin="1" CountMax="1" ItemCat="14" ItemIndex="371" ItemMinLevel="0" ItemMaxLevel="0" Skill="0" Luck="0" Option="0" Exc="-1" SetItem="0" SocketCount="0" ElementalItem="0" Rate="500000" />
 			</RewardKind>
 		</Category>
@@ -124,10 +124,10 @@
 	<Converter Level="3">
 		<Category Number="1">
 			<RewardKind Number="0">
-				<Reward Type="2" CountMin="400" CountMax="400" ItemCat="-1" ItemIndex="-1" ItemMinLevel="0" ItemMaxLevel="0" Skill="0" Luck="0" Option="0" Exc="-1" SetItem="0" SocketCount="0" ElementalItem="0" Rate="1000000" />
+				<Reward Type="2" CountMin="16" CountMax="16" ItemCat="-1" ItemIndex="-1" ItemMinLevel="0" ItemMaxLevel="0" Skill="0" Luck="0" Option="0" Exc="-1" SetItem="0" SocketCount="0" ElementalItem="0" Rate="1000000" />
 			</RewardKind>
 			<RewardKind Number="1">
-				<Reward Type="2" CountMin="200" CountMax="4000" ItemCat="-1" ItemIndex="-1" ItemMinLevel="0" ItemMaxLevel="0" Skill="0" Luck="0" Option="0" Exc="-1" SetItem="0" SocketCount="0" ElementalItem="0" Rate="500000" />
+				<Reward Type="2" CountMin="8" CountMax="160" ItemCat="-1" ItemIndex="-1" ItemMinLevel="0" ItemMaxLevel="0" Skill="0" Luck="0" Option="0" Exc="-1" SetItem="0" SocketCount="0" ElementalItem="0" Rate="500000" />
 				<Reward Type="0" CountMin="1" CountMax="1" ItemCat="14" ItemIndex="372" ItemMinLevel="0" ItemMaxLevel="0" Skill="0" Luck="0" Option="0" Exc="-1" SetItem="0" SocketCount="0" ElementalItem="0" Rate="500000" />
 			</RewardKind>
 		</Category>
@@ -182,10 +182,10 @@
 	<Converter Level="4">
 		<Category Number="1">
 			<RewardKind Number="0">
-				<Reward Type="2" CountMin="400" CountMax="400" ItemCat="-1" ItemIndex="-1" ItemMinLevel="0" ItemMaxLevel="0" Skill="0" Luck="0" Option="0" Exc="-1" SetItem="0" SocketCount="0" ElementalItem="0" Rate="1000000" />
+				<Reward Type="2" CountMin="16" CountMax="16" ItemCat="-1" ItemIndex="-1" ItemMinLevel="0" ItemMaxLevel="0" Skill="0" Luck="0" Option="0" Exc="-1" SetItem="0" SocketCount="0" ElementalItem="0" Rate="1000000" />
 			</RewardKind>
 			<RewardKind Number="1">
-				<Reward Type="2" CountMin="200" CountMax="4000" ItemCat="-1" ItemIndex="-1" ItemMinLevel="0" ItemMaxLevel="0" Skill="0" Luck="0" Option="0" Exc="-1" SetItem="0" SocketCount="0" ElementalItem="0" Rate="500000" />
+				<Reward Type="2" CountMin="8" CountMax="160" ItemCat="-1" ItemIndex="-1" ItemMinLevel="0" ItemMaxLevel="0" Skill="0" Luck="0" Option="0" Exc="-1" SetItem="0" SocketCount="0" ElementalItem="0" Rate="500000" />
 				<Reward Type="0" CountMin="1" CountMax="1" ItemCat="14" ItemIndex="372" ItemMinLevel="0" ItemMaxLevel="0" Skill="0" Luck="0" Option="0" Exc="-1" SetItem="0" SocketCount="0" ElementalItem="0" Rate="500000" />
 			</RewardKind>
 		</Category>
@@ -240,10 +240,10 @@
 	<Converter Level="5">
 		<Category Number="1">
 			<RewardKind Number="0">
-				<Reward Type="2" CountMin="400" CountMax="400" ItemCat="-1" ItemIndex="-1" ItemMinLevel="0" ItemMaxLevel="0" Skill="0" Luck="0" Option="0" Exc="-1" SetItem="0" SocketCount="0" ElementalItem="0" Rate="1000000" />
+				<Reward Type="2" CountMin="16" CountMax="16" ItemCat="-1" ItemIndex="-1" ItemMinLevel="0" ItemMaxLevel="0" Skill="0" Luck="0" Option="0" Exc="-1" SetItem="0" SocketCount="0" ElementalItem="0" Rate="1000000" />
 			</RewardKind>
 			<RewardKind Number="1">
-				<Reward Type="2" CountMin="200" CountMax="4000" ItemCat="-1" ItemIndex="-1" ItemMinLevel="0" ItemMaxLevel="0" Skill="0" Luck="0" Option="0" Exc="-1" SetItem="0" SocketCount="0" ElementalItem="0" Rate="500000" />
+				<Reward Type="2" CountMin="8" CountMax="160" ItemCat="-1" ItemIndex="-1" ItemMinLevel="0" ItemMaxLevel="0" Skill="0" Luck="0" Option="0" Exc="-1" SetItem="0" SocketCount="0" ElementalItem="0" Rate="500000" />
 				<Reward Type="0" CountMin="1" CountMax="1" ItemCat="14" ItemIndex="372" ItemMinLevel="0" ItemMaxLevel="0" Skill="0" Luck="0" Option="0" Exc="-1" SetItem="0" SocketCount="0" ElementalItem="0" Rate="500000" />
 			</RewardKind>
 		</Category>


### PR DESCRIPTION
I edited the Monster Soul Converter in two ways:
- The rewards should now really not be extremely high (all ruud divided by 25)
- Originally you need to kill 500 of two mobs, but this seems bugged, so I made it 1000 of one mob :)